### PR TITLE
Update github-release task

### DIFF
--- a/commands/publish/github-release
+++ b/commands/publish/github-release
@@ -60,7 +60,7 @@ begin
   assets.each do |asset|
     local_name, remote_name = *asset.split(':', 2)
     remote_name ||= local_name
-    uri = json["upload_url"].sub(/\{\?name\}$/, "?name=#{remote_name}")
+    uri = json["upload_url"].sub(/\{\?name,label\}$/, "?name=#{remote_name}")
     File.open(local_name, "r") do |file|
       begin
         https_request uri: uri, key: key,


### PR DESCRIPTION
CC @lsegal 

This change updates the `github-release` task to work with the GitHub release API changes.

Before the change the `upload_url` was as follows:
`https://uploads.github.com/repos/aws/aws-sdk-js/releases/1831054/assets{?name}`

After the change the `upload_url` returned is as follows:
`https://uploads.github.com/repos/aws/aws-sdk-js/releases/1831054/assets{?name,label}`

This change corrects the regular expression used to parse the `upload_url`
